### PR TITLE
feat(api): add CRUD endpoints for nodes and item transits

### DIFF
--- a/app/api/item-instance/[id]/route.ts
+++ b/app/api/item-instance/[id]/route.ts
@@ -1,0 +1,168 @@
+import { NextRequest } from 'next/server';
+import { 
+  createSuccessResponse, 
+  createErrorResponse, 
+  getSupabaseClient,
+  validateUUID,
+  handleApiError,
+  transformDbToApi,
+  ITEM_INSTANCE_FIELD_MAPPING
+} from '@/lib/api-helpers';
+import { UpdateItemInstanceRequest } from '@/lib/api-types';
+
+// GET /api/item-instance/[id] - Read Item Instance
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  return handleApiError(async () => {
+    const { id: itemInstanceId } = await params;
+    
+    if (!validateUUID(itemInstanceId)) {
+      return createErrorResponse('Invalid item instance ID format');
+    }
+
+    const supabase = await getSupabaseClient();
+    
+    const { data, error } = await supabase
+      .from('item_instances')
+      .select(`
+        *,
+        item_types (
+          item_id,
+          item_name,
+          item_type,
+          item_description
+        ),
+        nodes (
+          node_id,
+          node_name,
+          node_type
+        )
+      `)
+      .eq('item_instance_id', itemInstanceId)
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        return createErrorResponse('Item instance not found', 404);
+      }
+      console.error('Item instance fetch error:', error);
+      return createErrorResponse('Failed to fetch item instance', 500);
+    }
+
+    // Transform data to match API response format
+    const transformedData = {
+      ...transformDbToApi(data, ITEM_INSTANCE_FIELD_MAPPING),
+      item_type: data.item_types ? {
+        item_id: data.item_types.item_id,
+        item_name: data.item_types.item_name,
+        item_type: data.item_types.item_type,
+        item_description: data.item_types.item_description
+      } : null,
+      current_node: data.nodes ? {
+        node_id: data.nodes.node_id,
+        node_name: data.nodes.node_name,
+        node_type: data.nodes.node_type
+      } : null
+    };
+
+    return createSuccessResponse('Item instance retrieved successfully', transformedData);
+  });
+}
+
+// PUT /api/item-instance/[id] - Update Item Instance
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  return handleApiError(async () => {
+    const { id: itemInstanceId } = await params;
+    
+    if (!validateUUID(itemInstanceId)) {
+      return createErrorResponse('Invalid item instance ID format');
+    }
+
+    const body: UpdateItemInstanceRequest = await request.json();
+    
+    // Validate node_id if provided
+    if (body.node_id && !validateUUID(body.node_id)) {
+      return createErrorResponse('Invalid node_id format');
+    }
+
+    // Validate item_count if provided
+    if (body.item_count !== undefined && body.item_count <= 0) {
+      return createErrorResponse('item_count must be greater than 0');
+    }
+
+    const supabase = await getSupabaseClient();
+    
+    // Create update object with only provided fields
+    const updateData: any = {};
+    if (body.node_id !== undefined) updateData.node_id = body.node_id;
+    if (body.item_count !== undefined) updateData.item_count = body.item_count;
+    if (body.expire_date !== undefined) updateData.expire_date = body.expire_date;
+    if (body.status !== undefined) updateData.status = body.status;
+
+    const { data, error } = await supabase
+      .from('item_instances')
+      .update(updateData)
+      .eq('item_instance_id', itemInstanceId)
+      .select()
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        return createErrorResponse('Item instance not found', 404);
+      }
+      if (error.code === '23503') {
+        return createErrorResponse('Invalid node_id', 400);
+      }
+      console.error('Item instance update error:', error);
+      return createErrorResponse('Failed to update item instance', 500);
+    }
+
+    const transformedData = transformDbToApi(data, ITEM_INSTANCE_FIELD_MAPPING);
+    return createSuccessResponse('Item instance updated successfully', transformedData);
+  });
+}
+
+// DELETE /api/item-instance/[id] - Delete Item Instance (Soft Delete)
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  return handleApiError(async () => {
+    const { id: itemInstanceId } = await params;
+    
+    if (!validateUUID(itemInstanceId)) {
+      return createErrorResponse('Invalid item instance ID format');
+    }
+
+    const supabase = await getSupabaseClient();
+    
+    // Soft delete by setting status to disabled ('Inactive')
+    const { data, error } = await supabase
+      .from('item_instances')
+      .update({ 
+        status: 'Inactive' // 'Inactive' = disabled
+      })
+      .eq('item_instance_id', itemInstanceId)
+      .select('item_instance_id, status')
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        return createErrorResponse('Item instance not found', 404);
+      }
+      console.error('Item instance delete error:', error);
+      return createErrorResponse('Failed to delete item instance', 500);
+    }
+
+    return createSuccessResponse('Item instance deleted successfully', {
+      item_instance_id: data.item_instance_id,
+      deleted_at: new Date().toISOString(), // Client-side timestamp
+      status: data.status
+    });
+  });
+}

--- a/app/api/item-instance/route.ts
+++ b/app/api/item-instance/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest } from 'next/server';
+import { 
+  createSuccessResponse, 
+  createErrorResponse, 
+  getSupabaseClient,
+  validateRequired,
+  validateUUID,
+  handleApiError,
+  transformDbToApi,
+  ITEM_INSTANCE_FIELD_MAPPING
+} from '@/lib/api-helpers';
+import { CreateItemInstanceRequest } from '@/lib/api-types';
+
+// POST /api/item-instance - Create Item Instance
+export async function POST(request: NextRequest) {
+  return handleApiError(async () => {
+    const body: CreateItemInstanceRequest = await request.json();
+    
+    // Validate required fields
+    const missingFields = validateRequired(body, ['item_type_id', 'item_count']);
+    if (missingFields.length > 0) {
+      return createErrorResponse(`Missing required fields: ${missingFields.join(', ')}`);
+    }
+
+    // Validate UUIDs
+    if (!validateUUID(body.item_type_id)) {
+      return createErrorResponse('Invalid item_type_id format');
+    }
+    if (body.node_id && !validateUUID(body.node_id)) {
+      return createErrorResponse('Invalid node_id format');
+    }
+
+    // Validate item_count
+    if (body.item_count <= 0) {
+      return createErrorResponse('item_count must be greater than 0');
+    }
+
+    const supabase = await getSupabaseClient();
+    
+    // Insert item instance
+    const { data, error } = await supabase
+      .from('item_instances')
+      .insert({
+        item_type_id: body.item_type_id,
+        node_id: body.node_id || null,
+        item_count: body.item_count,
+        expire_date: body.expire_date || null,
+        status: 'Active' // default to active
+      })
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Item instance creation error:', error);
+      if (error.code === '23503') {
+        return createErrorResponse('Invalid item_type_id or node_id', 400);
+      }
+      return createErrorResponse('Failed to create item instance', 500);
+    }
+
+    const transformedData = transformDbToApi(data, ITEM_INSTANCE_FIELD_MAPPING);
+    return createSuccessResponse('Item instance created successfully', transformedData);
+  });
+}

--- a/app/api/item-instances/route.ts
+++ b/app/api/item-instances/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest } from 'next/server';
+import { 
+  createSuccessResponse, 
+  createErrorResponse, 
+  getPaginationParams,
+  createPaginationMeta,
+  getSupabaseClient,
+  handleApiError,
+  transformDbToApi,
+  ITEM_INSTANCE_FIELD_MAPPING
+} from '@/lib/api-helpers';
+
+// GET /api/item-instances - List Item Instances by Node with filtering
+export async function GET(request: NextRequest) {
+  return handleApiError(async () => {
+    const { searchParams } = new URL(request.url);
+    const paginationParams = getPaginationParams(searchParams);
+    const page = paginationParams.page || 1;
+    const page_size = paginationParams.page_size || 50;
+    
+    // Optional filters
+    const node_id = searchParams.get('node_id');
+    const item_type_id = searchParams.get('item_type_id');
+    const status = searchParams.get('status');
+    const expired = searchParams.get('expired') === 'true';
+    
+    const supabase = await getSupabaseClient();
+    
+    let query = supabase
+      .from('item_instances')
+      .select(`
+        *,
+        item_types (
+          item_id,
+          item_name,
+          item_type
+        ),
+        nodes (
+          node_id,
+          node_name,
+          node_type
+        )
+      `, { count: 'exact' });
+    
+    // Default filter: only show active instances unless status is explicitly specified
+    if (status === null) {
+      query = query.eq('status', 'Active');
+    } else {
+      // Apply status filter if explicitly provided
+      if (status === 'active') {
+        query = query.eq('status', 'Active');
+      } else if (status === 'inactive') {
+        query = query.eq('status', 'Inactive');
+      }
+    }
+    
+    // Apply additional filters
+    if (node_id) {
+      query = query.eq('node_id', node_id);
+    }
+    if (item_type_id) {
+      query = query.eq('item_type_id', item_type_id);
+    }
+    if (expired) {
+      query = query.lt('expire_date', new Date().toISOString());
+    }
+    
+    // Apply pagination
+    const from = (page - 1) * page_size;
+    const to = from + page_size - 1;
+    
+    const { data, error, count } = await query
+      .range(from, to)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      console.error('Item instances fetch error:', error);
+      return createErrorResponse('Failed to fetch item instances', 500);
+    }
+
+    // Transform data to match API response format
+    const transformedData = data?.map((item: any) => ({
+      ...transformDbToApi(item, ITEM_INSTANCE_FIELD_MAPPING),
+      item_type: item.item_types ? {
+        item_id: item.item_types.item_id,
+        item_name: item.item_types.item_name,
+        item_type: item.item_types.item_type
+      } : null,
+      current_node: item.nodes ? {
+        node_id: item.nodes.node_id,
+        node_name: item.nodes.node_name,
+        node_type: item.nodes.node_type
+      } : null
+    })) || [];
+
+    const paginationMeta = createPaginationMeta(count || 0, page, page_size);
+
+    return createSuccessResponse('Item instances retrieved successfully', {
+      item_instances: transformedData,
+      pagination: paginationMeta
+    });
+  });
+}

--- a/app/api/item-transit/[id]/complete/route.ts
+++ b/app/api/item-transit/[id]/complete/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest } from 'next/server';
+import { 
+  createSuccessResponse, 
+  createErrorResponse, 
+  getSupabaseClient,
+  validateRequired,
+  validateUUID,
+  handleApiError
+} from '@/lib/api-helpers';
+import { CompleteTransitRequest } from '@/lib/api-types';
+
+// POST /api/item-transit/[id]/complete - Complete Item Transit
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  return handleApiError(async () => {
+    const { id: transitId } = await params;
+    
+    if (!validateUUID(transitId)) {
+      return createErrorResponse('Invalid transit ID format');
+    }
+
+    const body: CompleteTransitRequest = await request.json();
+    
+    // Validate required fields
+    const missingFields = validateRequired(body, ['time_arrival']);
+    if (missingFields.length > 0) {
+      return createErrorResponse(`Missing required fields: ${missingFields.join(', ')}`);
+    }
+
+    const supabase = await getSupabaseClient();
+    
+    // First, get the transit details to update the item instance
+    const { data: transitData, error: fetchError } = await supabase
+      .from('item_transits')
+      .select('item_instance_id, dest_node_id, time_departure')
+      .eq('item_transit_id', transitId)
+      .single();
+
+    if (fetchError) {
+      if (fetchError.code === 'PGRST116') {
+        return createErrorResponse('Item transit not found', 404);
+      }
+      console.error('Transit fetch error:', fetchError);
+      return createErrorResponse('Failed to fetch transit details', 500);
+    }
+
+    // Update transit to completed
+    const { data, error } = await supabase
+      .from('item_transits')
+      .update({
+        time_arrival: body.time_arrival
+        // status: 'Completed' // Temporarily disabled - column may not exist
+      })
+      .eq('item_transit_id', transitId)
+      .select('item_transit_id, time_departure, time_arrival, status, item_instance_id')
+      .single();
+
+    if (error) {
+      console.error('Transit completion error:', error);
+      return createErrorResponse('Failed to complete transit', 500);
+    }
+
+    // Update item instance location if dest_node_id exists
+    if (transitData.dest_node_id) {
+      const { error: updateError } = await supabase
+        .from('item_instances')
+        .update({ node_id: transitData.dest_node_id })
+        .eq('item_instance_id', transitData.item_instance_id);
+
+      if (updateError) {
+        console.error('Item instance location update error:', updateError);
+        // Continue anyway, transit completion was successful
+      }
+    }
+
+    // Calculate duration
+    const departureTime = new Date(transitData.time_departure);
+    const arrivalTime = new Date(body.time_arrival);
+    const durationMinutes = Math.floor((arrivalTime.getTime() - departureTime.getTime()) / (1000 * 60));
+
+    return createSuccessResponse('Item transit completed successfully', {
+      item_transit_id: data.item_transit_id,
+      completed_at: data.time_arrival,
+      time_departure: data.time_departure,
+      time_arrival: data.time_arrival,
+      duration_minutes: durationMinutes,
+      status: data.status,
+      item_instance: {
+        item_instance_id: data.item_instance_id,
+        new_location: transitData.dest_node_id ? {
+          node_id: transitData.dest_node_id,
+          node_name: 'Updated Location' // This would need a join to get actual name
+        } : null
+      }
+    });
+  });
+}

--- a/app/api/item-transit/[id]/route.ts
+++ b/app/api/item-transit/[id]/route.ts
@@ -1,0 +1,138 @@
+import { NextRequest } from 'next/server';
+import { 
+  createSuccessResponse, 
+  createErrorResponse, 
+  getSupabaseClient,
+  validateUUID,
+  handleApiError,
+  transformDbToApi,
+  ITEM_TRANSIT_FIELD_MAPPING
+} from '@/lib/api-helpers';
+import { UpdateItemTransitRequest, CompleteTransitRequest } from '@/lib/api-types';
+
+// GET /api/item-transit/[id] - Read Item Transit
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  return handleApiError(async () => {
+    const { id: transitId } = await params;
+    
+    if (!validateUUID(transitId)) {
+      return createErrorResponse('Invalid transit ID format');
+    }
+
+    const supabase = await getSupabaseClient();
+    
+    const { data, error } = await supabase
+      .from('item_transits')
+      .select(`
+        *,
+        item_instances (
+          item_instance_id,
+          item_count,
+          item_types (
+            item_name,
+            item_type
+          )
+        ),
+        source_nodes:nodes!source_node_id (
+          node_id,
+          node_name,
+          node_type
+        ),
+        dest_nodes:nodes!dest_node_id (
+          node_id,
+          node_name,
+          node_type
+        )
+      `)
+      .eq('item_transit_id', transitId)
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        return createErrorResponse('Item transit not found', 404);
+      }
+      console.error('Item transit fetch error:', error);
+      return createErrorResponse('Failed to fetch item transit', 500);
+    }
+
+    // Transform data to match API response format
+    const transformedData = {
+      ...transformDbToApi(data, ITEM_TRANSIT_FIELD_MAPPING),
+      item_instance: data.item_instances ? {
+        item_instance_id: data.item_instances.item_instance_id,
+        item_count: data.item_instances.item_count,
+        item_type: data.item_instances.item_types ? {
+          item_name: data.item_instances.item_types.item_name,
+          item_type: data.item_instances.item_types.item_type
+        } : null
+      } : null,
+      source_node: data.source_nodes ? {
+        node_id: data.source_nodes.node_id,
+        node_name: data.source_nodes.node_name,
+        node_type: data.source_nodes.node_type
+      } : null,
+      dest_node: data.dest_nodes ? {
+        node_id: data.dest_nodes.node_id,
+        node_name: data.dest_nodes.node_name,
+        node_type: data.dest_nodes.node_type
+      } : null
+    };
+
+    return createSuccessResponse('Item transit retrieved successfully', transformedData);
+  });
+}
+
+// PUT /api/item-transit/[id] - Update Item Transit
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  return handleApiError(async () => {
+    const { id: transitId } = await params;
+    
+    if (!validateUUID(transitId)) {
+      return createErrorResponse('Invalid transit ID format');
+    }
+
+    const body: UpdateItemTransitRequest = await request.json();
+    
+    // Validate dest_node_id if provided
+    if (body.dest_node_id && !validateUUID(body.dest_node_id)) {
+      return createErrorResponse('Invalid dest_node_id format');
+    }
+
+    const supabase = await getSupabaseClient();
+    
+    // Create update object with only provided fields
+    const updateData: any = {};
+    if (body.dest_node_id !== undefined) updateData.dest_node_id = body.dest_node_id;
+    if (body.time_arrival !== undefined) updateData.time_arrival = body.time_arrival;
+    if (body.courier_name !== undefined) updateData.courier_name = body.courier_name;
+    if (body.courier_phone !== undefined) updateData.courier_phone = body.courier_phone;
+    if (body.status !== undefined) updateData.status = body.status;
+
+    const { data, error } = await supabase
+      .from('item_transits')
+      .update(updateData)
+      .eq('item_transit_id', transitId)
+      .select()
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        return createErrorResponse('Item transit not found', 404);
+      }
+      if (error.code === '23503') {
+        return createErrorResponse('Invalid dest_node_id', 400);
+      }
+      console.error('Item transit update error:', error);
+      return createErrorResponse('Failed to update item transit', 500);
+    }
+
+    const transformedData = transformDbToApi(data, ITEM_TRANSIT_FIELD_MAPPING);
+    return createSuccessResponse('Item transit updated successfully', transformedData);
+  });
+}

--- a/app/api/item-transit/route.ts
+++ b/app/api/item-transit/route.ts
@@ -11,7 +11,7 @@ import {
 } from '@/lib/api-helpers';
 import { CreateItemTransitRequest } from '@/lib/api-types';
 
-// POST /api/transit - Create Item Transit (rename to /api/item-transit)
+// POST /api/item-transit - Create Item Transit
 export async function POST(request: NextRequest) {
   return handleApiError(async () => {
     const body: CreateItemTransitRequest = await request.json();
@@ -45,8 +45,8 @@ export async function POST(request: NextRequest) {
         time_departure: body.time_departure,
         courier_name: body.courier_name || null,
         courier_phone: body.courier_phone || null,
-        qr_url: body.qr_url || null,
-        status: body.status || 'Active'
+        qr_url: body.qr_url || null
+        // status: body.status || 'Active' // Temporarily disabled - column may not exist
       })
       .select()
       .single();

--- a/app/api/item-transits/route.ts
+++ b/app/api/item-transits/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest } from 'next/server';
+import { 
+  createSuccessResponse, 
+  createErrorResponse, 
+  getPaginationParams,
+  createPaginationMeta,
+  getSupabaseClient,
+  handleApiError,
+  transformDbToApi,
+  ITEM_TRANSIT_FIELD_MAPPING
+} from '@/lib/api-helpers';
+
+// GET /api/item-transits - List Active Transits
+export async function GET(request: NextRequest) {
+  return handleApiError(async () => {
+    const { searchParams } = new URL(request.url);
+    const paginationParams = getPaginationParams(searchParams);
+    const page = paginationParams.page || 1;
+    const page_size = paginationParams.page_size || 50;
+    
+    // Optional filters
+    const source_node_id = searchParams.get('source_node_id');
+    const dest_node_id = searchParams.get('dest_node_id');
+    const status = searchParams.get('status');
+    const courier_name = searchParams.get('courier_name');
+    
+    const supabase = await getSupabaseClient();
+    
+    let query = supabase
+      .from('item_transits')
+      .select(`
+        *,
+        item_instances (
+          item_instance_id,
+          item_count,
+          item_types (
+            item_name,
+            item_type
+          )
+        ),
+        source_nodes:nodes!source_node_id (
+          node_id,
+          node_name
+        ),
+        dest_nodes:nodes!dest_node_id (
+          node_id,
+          node_name
+        )
+      `, { count: 'exact' });
+    
+    // Apply additional filters
+    if (source_node_id) {
+      query = query.eq('source_node_id', source_node_id);
+    }
+    if (dest_node_id) {
+      query = query.eq('dest_node_id', dest_node_id);
+    }
+    if (courier_name) {
+      query = query.ilike('courier_name', `%${courier_name}%`);
+    }
+    
+    // TODO: Add status filtering once column is confirmed to exist
+    // For now, temporarily disabled due to column not found error
+    
+    // Apply pagination
+    const from = (page - 1) * page_size;
+    const to = from + page_size - 1;
+    
+    const { data, error, count } = await query
+      .range(from, to)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      console.error('Transit records fetch error:', error);
+      return createErrorResponse('Failed to fetch transit records', 500);
+    }
+
+    // Transform data to match API response format
+    const transformedData = data?.map((item: any) => ({
+      ...transformDbToApi(item, ITEM_TRANSIT_FIELD_MAPPING),
+      item_instance: item.item_instances ? {
+        item_instance_id: item.item_instances.item_instance_id,
+        item_count: item.item_instances.item_count,
+        item_type: item.item_instances.item_types ? {
+          item_name: item.item_instances.item_types.item_name,
+          item_type: item.item_instances.item_types.item_type
+        } : null
+      } : null,
+      source_node: item.source_nodes ? {
+        node_id: item.source_nodes.node_id,
+        node_name: item.source_nodes.node_name
+      } : null,
+      dest_node: item.dest_nodes ? {
+        node_id: item.dest_nodes.node_id,
+        node_name: item.dest_nodes.node_name
+      } : null
+    })) || [];
+
+    // Calculate summary statistics
+    const activeTransits = transformedData.filter((item: any) => item.status === 'Active');
+    const durations = transformedData
+      .filter((item: any) => item.time_arrival && item.time_departure)
+      .map((item: any) => {
+        const departure = new Date(item.time_departure);
+        const arrival = new Date(item.time_arrival);
+        return (arrival.getTime() - departure.getTime()) / (1000 * 60); // minutes
+      });
+
+    const summary = {
+      total_active_transits: activeTransits.length,
+      average_duration_minutes: durations.length > 0 ? Math.round(durations.reduce((a, b) => a + b, 0) / durations.length) : 0,
+      longest_transit_days: durations.length > 0 ? Math.round(Math.max(...durations) / (60 * 24)) : 0
+    };
+
+    const paginationMeta = createPaginationMeta(count || 0, page, page_size);
+
+    return createSuccessResponse('Transit records retrieved successfully', {
+      transits: transformedData,
+      summary,
+      pagination: paginationMeta
+    });
+  });
+}

--- a/app/api/item-type/[id]/route.ts
+++ b/app/api/item-type/[id]/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest } from 'next/server';
+import { 
+  createSuccessResponse, 
+  createErrorResponse, 
+  getSupabaseClient,
+  validateUUID,
+  handleApiError,
+  transformDbToApi,
+  ITEM_TYPE_FIELD_MAPPING
+} from '@/lib/api-helpers';
+import { UpdateItemTypeRequest } from '@/lib/api-types';
+
+// GET /api/item-type/[id] - Read Item Type
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  return handleApiError(async () => {
+    const { id: itemId } = await params;
+    
+    if (!validateUUID(itemId)) {
+      return createErrorResponse('Invalid item type ID format');
+    }
+
+    const supabase = await getSupabaseClient();
+    
+    const { data, error } = await supabase
+      .from('item_types')
+      .select('*')
+      .eq('item_id', itemId)
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        return createErrorResponse('Item type not found', 404);
+      }
+      console.error('Item type fetch error:', error);
+      return createErrorResponse('Failed to fetch item type', 500);
+    }
+
+    const transformedData = transformDbToApi(data, ITEM_TYPE_FIELD_MAPPING);
+    return createSuccessResponse('Item type retrieved successfully', transformedData);
+  });
+}
+
+// PUT /api/item-type/[id] - Update Item Type
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  return handleApiError(async () => {
+    const { id: itemId } = await params;
+    
+    if (!validateUUID(itemId)) {
+      return createErrorResponse('Invalid item type ID format');
+    }
+
+    const body: UpdateItemTypeRequest = await request.json();
+    const supabase = await getSupabaseClient();
+    
+    // Create update object with only provided fields
+    const updateData: any = {};
+    if (body.item_name) updateData.item_name = body.item_name;
+    if (body.item_type) updateData.item_type = body.item_type;
+    if (body.item_description !== undefined) updateData.item_description = body.item_description;
+    if (body.item_image !== undefined) updateData.item_image = body.item_image;
+    if (body.status !== undefined) updateData.status = body.status;
+
+    const { data, error } = await supabase
+      .from('item_types')
+      .update(updateData)
+      .eq('item_id', itemId)
+      .select()
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        return createErrorResponse('Item type not found', 404);
+      }
+      console.error('Item type update error:', error);
+      return createErrorResponse('Failed to update item type', 500);
+    }
+
+    const transformedData = transformDbToApi(data, ITEM_TYPE_FIELD_MAPPING);
+    return createSuccessResponse('Item type updated successfully', transformedData);
+  });
+}
+
+// DELETE /api/item-type/[id] - Delete Item Type (Soft Delete)
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  return handleApiError(async () => {
+    const { id: itemId } = await params;
+    
+    if (!validateUUID(itemId)) {
+      return createErrorResponse('Invalid item type ID format');
+    }
+
+    const supabase = await getSupabaseClient();
+    
+    // Soft delete by setting status to disabled ('Inactive')
+    const { data, error } = await supabase
+      .from('item_types')
+      .update({ 
+        status: 'Inactive' // 'Inactive' = disabled
+      })
+      .eq('item_id', itemId)
+      .select('item_id, status')
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        return createErrorResponse('Item type not found', 404);
+      }
+      console.error('Item type delete error:', error);
+      return createErrorResponse('Failed to delete item type', 500);
+    }
+
+    return createSuccessResponse('Item type deleted successfully', {
+      item_id: data.item_id,
+      deleted_at: new Date().toISOString(), // Client-side timestamp
+      status: data.status
+    });
+  });
+}

--- a/app/api/item-type/route.ts
+++ b/app/api/item-type/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest } from 'next/server';
+import { 
+  createSuccessResponse, 
+  createErrorResponse, 
+  getSupabaseClient,
+  validateRequired,
+  handleApiError,
+  transformDbToApi,
+  ITEM_TYPE_FIELD_MAPPING
+} from '@/lib/api-helpers';
+import { CreateItemTypeRequest } from '@/lib/api-types';
+
+// POST /api/item-type - Create Item Type
+export async function POST(request: NextRequest) {
+  return handleApiError(async () => {
+    const body: CreateItemTypeRequest = await request.json();
+    
+    // Validate required fields
+    const missingFields = validateRequired(body, ['item_name', 'item_type']);
+    if (missingFields.length > 0) {
+      return createErrorResponse(`Missing required fields: ${missingFields.join(', ')}`);
+    }
+
+    const supabase = await getSupabaseClient();
+    
+    // Insert item type
+    const { data, error } = await supabase
+      .from('item_types')
+      .insert({
+        item_name: body.item_name,
+        item_type: body.item_type,
+        item_description: body.item_description || null,
+        item_image: body.item_image || null,
+        status: 'Active' // default to active
+      })
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Item type creation error:', error);
+      return createErrorResponse('Failed to create item type', 500);
+    }
+
+    const transformedData = transformDbToApi(data, ITEM_TYPE_FIELD_MAPPING);
+    return createSuccessResponse('Item type created successfully', transformedData);
+  });
+}

--- a/app/api/item-types/route.ts
+++ b/app/api/item-types/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest } from 'next/server';
+import { 
+  createSuccessResponse, 
+  createErrorResponse, 
+  getPaginationParams,
+  createPaginationMeta,
+  getSupabaseClient,
+  handleApiError,
+  transformDbToApi,
+  ITEM_TYPE_FIELD_MAPPING
+} from '@/lib/api-helpers';
+
+// GET /api/item-types - List All Item Types with filtering and pagination
+export async function GET(request: NextRequest) {
+  return handleApiError(async () => {
+    const { searchParams } = new URL(request.url);
+    const paginationParams = getPaginationParams(searchParams);
+    const page = paginationParams.page || 1;
+    const page_size = paginationParams.page_size || 50;
+    
+    // Optional filters
+    const item_type = searchParams.get('item_type');
+    const status = searchParams.get('status');
+    
+    const supabase = await getSupabaseClient();
+    
+    let query = supabase.from('item_types').select('*', { count: 'exact' });
+    
+    // Default filter: only show active items unless status is explicitly specified
+    if (status === null) {
+      query = query.eq('status', 'Active');
+    } else {
+      // Apply status filter if explicitly provided
+      if (status === 'active') {
+        query = query.eq('status', 'Active');
+      } else if (status === 'inactive') {
+        query = query.eq('status', 'Inactive');
+      }
+    }
+    
+    // Apply additional filters
+    if (item_type) {
+      query = query.eq('item_type', item_type);
+    }
+    
+    // Apply pagination
+    const from = (page - 1) * page_size;
+    const to = from + page_size - 1;
+    
+    const { data, error, count } = await query
+      .range(from, to)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      console.error('Item types fetch error:', error);
+      return createErrorResponse('Failed to fetch item types', 500);
+    }
+
+    const transformedData = data?.map((item: any) => transformDbToApi(item, ITEM_TYPE_FIELD_MAPPING)) || [];
+    const paginationMeta = createPaginationMeta(count || 0, page, page_size);
+
+    return createSuccessResponse('Item types retrieved successfully', {
+      item_types: transformedData,
+      pagination: paginationMeta
+    });
+  });
+}

--- a/app/api/items/active/route.ts
+++ b/app/api/items/active/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest } from 'next/server';
+import { 
+  createSuccessResponse, 
+  createErrorResponse, 
+  getPaginationParams,
+  createPaginationMeta,
+  getSupabaseClient,
+  handleApiError,
+  transformDbToApi,
+  ITEM_INSTANCE_FIELD_MAPPING
+} from '@/lib/api-helpers';
+
+// GET /api/items/active - Read All Active Items
+export async function GET(request: NextRequest) {
+  return handleApiError(async () => {
+    const { searchParams } = new URL(request.url);
+    const paginationParams = getPaginationParams(searchParams);
+    const page = paginationParams.page || 1;
+    const page_size = paginationParams.page_size || 50;
+    
+    // Optional filters
+    const node_id = searchParams.get('node_id');
+    const item_type_id = searchParams.get('item_type_id');
+    const expired = searchParams.get('expired') === 'true';
+    
+    const supabase = await getSupabaseClient();
+    
+    let query = supabase
+      .from('item_instances')
+      .select(`
+        *,
+        item_types (
+          id,
+          item_name,
+          item_type,
+          item_description,
+          item_image
+        ),
+        nodes (
+          id,
+          node_name,
+          node_type,
+          node_address
+        )
+      `, { count: 'exact' })
+      .eq('status', false); // Only active items
+    
+    // Apply filters
+    if (node_id) {
+      query = query.eq('node_id', node_id);
+    }
+    if (item_type_id) {
+      query = query.eq('item_type_id', item_type_id);
+    }
+    if (!expired) {
+      // Exclude expired items if not explicitly requested
+      query = query.or('expire_date.is.null,expire_date.gt.' + new Date().toISOString());
+    }
+    
+    // Apply pagination
+    const from = (page - 1) * page_size;
+    const to = from + page_size - 1;
+    
+    const { data, error, count } = await query
+      .range(from, to)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      console.error('Active items fetch error:', error);
+      return createErrorResponse('Failed to fetch active items', 500);
+    }
+
+    // Transform data to match API response format
+    const transformedData = data?.map((item: any) => ({
+      ...transformDbToApi(item, ITEM_INSTANCE_FIELD_MAPPING),
+      location_type: item.node_id ? 'node' : 'transit',
+      item_type: item.item_types ? {
+        item_id: item.item_types.id,
+        item_name: item.item_types.item_name,
+        item_type: item.item_types.item_type,
+        item_description: item.item_types.item_description,
+        item_image: item.item_types.item_image
+      } : null,
+      current_node: item.nodes ? {
+        node_id: item.nodes.id,
+        node_name: item.nodes.node_name,
+        node_type: item.nodes.node_type,
+        node_address: item.nodes.node_address
+      } : null
+    })) || [];
+
+    // Calculate summary statistics
+    const summary = {
+      total_active_items: count || 0,
+      items_in_nodes: transformedData.filter(item => item.location_type === 'node').length,
+      items_in_transit: transformedData.filter(item => item.location_type === 'transit').length,
+      expiring_soon: transformedData.filter(item => 
+        item.expire_date && 
+        new Date(item.expire_date) <= new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+      ).length
+    };
+
+    const paginationMeta = createPaginationMeta(count || 0, page, page_size);
+
+    return createSuccessResponse('Active items retrieved successfully', {
+      items: transformedData,
+      summary,
+      pagination: paginationMeta
+    });
+  });
+}

--- a/app/api/node/[id]/route.ts
+++ b/app/api/node/[id]/route.ts
@@ -1,0 +1,137 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { 
+  createSuccessResponse, 
+  createErrorResponse, 
+  getSupabaseClient,
+  validateUUID,
+  handleApiError,
+  transformDbToApi,
+  NODE_FIELD_MAPPING
+} from '@/lib/api-helpers';
+import { UpdateNodeRequest } from '@/lib/api-types';
+
+// GET /api/node/[id] - Read Node
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  return handleApiError(async () => {
+    const { id: nodeId } = await params;
+    
+    if (!validateUUID(nodeId)) {
+      return createErrorResponse('Invalid node ID format');
+    }
+
+    const supabase = await getSupabaseClient();
+    
+    const { data, error } = await supabase
+      .from('nodes')
+      .select('*')
+      .eq('node_id', nodeId)
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        return createErrorResponse('Node not found', 404);
+      }
+      console.error('Node fetch error:', error);
+      return createErrorResponse('Failed to fetch node', 500);
+    }
+
+    const transformedData = transformDbToApi(data, NODE_FIELD_MAPPING);
+    return createSuccessResponse('Node retrieved successfully', transformedData);
+  });
+}
+
+// PUT /api/node/[id] - Update Node
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  return handleApiError(async () => {
+    const { id: nodeId } = await params;
+    
+    if (!validateUUID(nodeId)) {
+      return createErrorResponse('Invalid node ID format');
+    }
+
+    const body: UpdateNodeRequest = await request.json();
+    
+    // Validate node_type if provided
+    if (body.node_type) {
+      const validNodeTypes = ['Source', 'Assembly', 'Distribution'];
+      if (!validNodeTypes.includes(body.node_type)) {
+        return createErrorResponse(`Invalid node_type. Must be one of: ${validNodeTypes.join(', ')}`);
+      }
+    }
+
+    const supabase = await getSupabaseClient();
+    
+    // Create update object with only provided fields
+    const updateData: any = {};
+    if (body.node_name) updateData.node_name = body.node_name;
+    if (body.node_type) updateData.node_type = body.node_type;
+    if (body.node_address !== undefined) updateData.node_address = body.node_address;
+    if (body.node_latitude !== undefined) updateData.node_latitude = body.node_latitude;
+    if (body.node_longitude !== undefined) updateData.node_longitude = body.node_longitude;
+    if (body.node_status !== undefined) updateData.node_status = body.node_status;
+
+    const { data, error } = await supabase
+      .from('nodes')
+      .update(updateData)
+      .eq('node_id', nodeId)
+      .select()
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        return createErrorResponse('Node not found', 404);
+      }
+      console.error('Node update error:', error);
+      return createErrorResponse('Failed to update node', 500);
+    }
+
+    const transformedData = transformDbToApi(data, NODE_FIELD_MAPPING);
+    return createSuccessResponse('Node updated successfully', transformedData);
+  });
+}
+
+// DELETE /api/node/[id] - Delete Node (Soft Delete)
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  return handleApiError(async () => {
+    const { id: nodeId } = await params;
+    
+    if (!validateUUID(nodeId)) {
+      return createErrorResponse('Invalid node ID format');
+    }
+
+    const supabase = await getSupabaseClient();
+    
+    // Soft delete by setting status to Inactive
+    const { data, error } = await supabase
+      .from('nodes')
+      .update({ 
+        node_status: 'Inactive' // Inactive status
+      })
+      .eq('node_id', nodeId)
+      .select('node_id, node_status')
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        return createErrorResponse('Node not found', 404);
+      }
+      console.error('Node delete error:', error);
+      return createErrorResponse('Failed to delete node', 500);
+    }
+
+    return createSuccessResponse('Node deleted successfully', {
+      node_id: data.node_id,
+      deleted_at: new Date().toISOString(), // Client-side timestamp since DB doesn't track this
+      status: data.node_status
+    });
+  });
+}

--- a/app/api/node/route.ts
+++ b/app/api/node/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest } from 'next/server';
+import { 
+  createSuccessResponse, 
+  createErrorResponse, 
+  getSupabaseClient,
+  validateRequired,
+  handleApiError,
+  transformDbToApi,
+  NODE_FIELD_MAPPING
+} from '@/lib/api-helpers';
+import { CreateNodeRequest } from '@/lib/api-types';
+
+// POST /api/node - Create Node
+export async function POST(request: NextRequest) {
+  return handleApiError(async () => {
+    const body: CreateNodeRequest = await request.json();
+    
+    // Validate required fields
+    const missingFields = validateRequired(body, ['node_name', 'node_type']);
+    if (missingFields.length > 0) {
+      return createErrorResponse(`Missing required fields: ${missingFields.join(', ')}`);
+    }
+
+    // Validate node_type
+    const validNodeTypes = ['Source', 'Assembly', 'Distribution'];
+    if (!validNodeTypes.includes(body.node_type)) {
+      return createErrorResponse(`Invalid node_type. Must be one of: ${validNodeTypes.join(', ')}`);
+    }
+
+    const supabase = await getSupabaseClient();
+    
+    // Insert node
+    const { data, error } = await supabase
+      .from('nodes')
+      .insert({
+        node_name: body.node_name,
+        node_type: body.node_type,
+        node_address: body.node_address || null,
+        node_latitude: body.node_latitude || null,
+        node_longitude: body.node_longitude || null,
+        node_status: body.node_status || 'Active' // default to Active
+      })
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Node creation error:', error);
+      return createErrorResponse('Failed to create node', 500);
+    }
+
+    const transformedData = transformDbToApi(data, NODE_FIELD_MAPPING);
+    return createSuccessResponse('Node successfully created', transformedData);
+  });
+}

--- a/app/api/nodes/route.ts
+++ b/app/api/nodes/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest } from 'next/server';
+import { 
+  createSuccessResponse, 
+  createErrorResponse, 
+  getPaginationParams,
+  createPaginationMeta,
+  getSupabaseClient,
+  handleApiError,
+  transformDbToApi,
+  NODE_FIELD_MAPPING
+} from '@/lib/api-helpers';
+
+// GET /api/nodes - List All Nodes with filtering and pagination
+export async function GET(request: NextRequest) {
+  return handleApiError(async () => {
+    const { searchParams } = new URL(request.url);
+    const paginationParams = getPaginationParams(searchParams);
+    const page = paginationParams.page || 1;
+    const page_size = paginationParams.page_size || 50;
+    
+    // Optional filters
+    const node_type = searchParams.get('node_type');
+    const status = searchParams.get('status');
+    
+    const supabase = await getSupabaseClient();
+    
+    let query = supabase.from('nodes').select('*', { count: 'exact' });
+    
+    // Default filter: only show active nodes unless status is explicitly specified
+    if (status === null) {
+      query = query.eq('node_status', 'Active');
+    } else {
+      // Apply status filter if explicitly provided
+      if (status === 'active') {
+        query = query.eq('node_status', 'Active');
+      } else if (status === 'inactive') {
+        query = query.eq('node_status', 'Inactive');
+      }
+    }
+    
+    // Apply filters
+    if (node_type) {
+      query = query.eq('node_type', node_type);
+    }
+    
+    // Apply pagination
+    const from = (page - 1) * page_size;
+    const to = from + page_size - 1;
+    
+    const { data, error, count } = await query
+      .range(from, to)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      console.error('Nodes fetch error:', error);
+      return createErrorResponse('Failed to fetch nodes', 500);
+    }
+
+    const transformedData = data?.map((item: any) => transformDbToApi(item, NODE_FIELD_MAPPING)) || [];
+    const paginationMeta = createPaginationMeta(count || 0, page, page_size);
+
+    return createSuccessResponse('Nodes retrieved successfully', {
+      nodes: transformedData,
+      pagination: paginationMeta
+    });
+  });
+}

--- a/docs/API/03_All-CRUD.md
+++ b/docs/API/03_All-CRUD.md
@@ -9,75 +9,73 @@ This document defines the parameters and responses for the basic CRUD operations
 
 - [All basic CRUD Operations](#all-basic-crud-operations)
   - [Table of Contents](#table-of-contents)
-  - [Node CRUD Endpoints](#node-crud-endpoints)
+  - [Overview](#overview)
+    - [Node CRUD Endpoints](#node-crud-endpoints)
+    - [Item Type CRUD Endpoints](#item-type-crud-endpoints)
+    - [Item Instance CRUD Endpoints](#item-instance-crud-endpoints)
+    - [Item Transit CRUD Endpoints](#item-transit-crud-endpoints)
+  - [Node CRUD Endpoints](#node-crud-endpoints-1)
     - [Create Node](#create-node)
-      - [Request Parameters](#request-parameters)
-      - [Response Format:](#response-format)
     - [Read Node](#read-node)
-      - [Request Parameters](#request-parameters-1)
-      - [Response Format:](#response-format-1)
     - [Update Node](#update-node)
-      - [Request Parameters](#request-parameters-2)
-      - [Response Format:](#response-format-2)
     - [Delete Node](#delete-node)
-      - [Request Parameters](#request-parameters-3)
-      - [Response Format:](#response-format-3)
     - [List All Nodes](#list-all-nodes)
-      - [Request Parameters](#request-parameters-4)
-      - [Response Format:](#response-format-4)
-  - [Item Type CRUD Endpoints](#item-type-crud-endpoints)
+  - [Item Type CRUD Endpoints](#item-type-crud-endpoints-1)
     - [Create Item Type](#create-item-type)
-      - [Request Parameters](#request-parameters-5)
-      - [Response Format:](#response-format-5)
     - [Read Item Type](#read-item-type)
-      - [Request Parameters](#request-parameters-6)
-      - [Response Format:](#response-format-6)
     - [Update Item Type](#update-item-type)
-      - [Request Parameters](#request-parameters-7)
-      - [Response Format:](#response-format-7)
     - [Delete Item Type](#delete-item-type)
-      - [Request Parameters](#request-parameters-8)
-      - [Response Format:](#response-format-8)
     - [List All Item Types](#list-all-item-types)
-      - [Request Parameters](#request-parameters-9)
-      - [Response Format:](#response-format-9)
-  - [Item Instance CRUD Endpoints](#item-instance-crud-endpoints)
+  - [Item Instance CRUD Endpoints](#item-instance-crud-endpoints-1)
     - [Create Item Instance](#create-item-instance)
-      - [Request Parameters](#request-parameters-10)
-      - [Response Format:](#response-format-10)
     - [Read Item Instance](#read-item-instance)
-      - [Request Parameters](#request-parameters-11)
-      - [Response Format:](#response-format-11)
     - [Read All Active Items](#read-all-active-items)
-      - [Request Parameters](#request-parameters-12)
-      - [Response Format:](#response-format-12)
     - [Update Item Instance](#update-item-instance)
-      - [Request Parameters](#request-parameters-13)
-      - [Response Format:](#response-format-13)
     - [Delete Item Instance](#delete-item-instance)
-      - [Request Parameters](#request-parameters-14)
-      - [Response Format:](#response-format-14)
     - [List Item Instances by Node](#list-item-instances-by-node)
-      - [Request Parameters](#request-parameters-15)
-      - [Response Format:](#response-format-15)
-  - [Item Transit CRUD Endpoints](#item-transit-crud-endpoints)
+  - [Item Transit CRUD Endpoints](#item-transit-crud-endpoints-1)
     - [Create Item Transit](#create-item-transit)
-      - [Request Parameters](#request-parameters-16)
-      - [Response Format:](#response-format-16)
     - [Read Item Transit](#read-item-transit)
-      - [Request Parameters](#request-parameters-17)
-      - [Response Format:](#response-format-17)
     - [Update Item Transit](#update-item-transit)
-      - [Request Parameters](#request-parameters-18)
-      - [Response Format:](#response-format-18)
     - [Complete Item Transit](#complete-item-transit)
-      - [Request Parameters](#request-parameters-19)
-      - [Response Format:](#response-format-19)
     - [List Active Transits](#list-active-transits)
-      - [Request Parameters](#request-parameters-20)
-      - [Response Format:](#response-format-20)
 
 ---
+
+## Overview
+
+### Node CRUD Endpoints
+
+- POST /api/node - Create new node
+- GET /api/node/[id] - Get specific node by ID
+- PUT /api/node/[id] - Update node
+- DELETE /api/node/[id] - Soft delete node (sets status to disabled)
+- GET /api/nodes - List all nodes with filtering and pagination
+
+### Item Type CRUD Endpoints
+
+- POST /api/item-type - Create new item type
+- GET /api/item-type/[id] - Get specific item type by ID
+- PUT /api/item-type/[id] - Update item type
+- DELETE /api/item-type/[id] - Soft delete item type
+- GET /api/item-types - List all item types with filtering and pagination
+
+### Item Instance CRUD Endpoints
+
+- POST /api/item-instance - Create new item instance
+- GET /api/item-instance/[id] - Get specific item instance with relations
+- PUT /api/item-instance/[id] - Update item instance
+- DELETE /api/item-instance/[id] - Soft delete item instance
+- GET /api/items/active - Get all active items with summary statistics
+- GET /api/item-instances - List item instances with filtering
+
+### Item Transit CRUD Endpoints
+
+- POST /api/item-transit - Create new item transit (with automatic item location update)
+- GET /api/item-transit/[id] - Get specific transit with relations
+- PUT /api/item-transit/[id] - Update item transit
+- POST /api/item-transit/[id]/complete - Complete transit and update item location
+- GET /api/item-transits - List transits with filtering and summary statistics
 
 ## Node CRUD Endpoints
 
@@ -89,7 +87,7 @@ CRUD operations for managing nodes in the system.
 
 **Description:** Creates a new node in the system.
 
-#### Request Parameters
+**Request Parameters:**
 
 | Parameter    | Type   | Location | Required | Description                           |
 | ------------ | ------ | -------- | -------- | ------------------------------------- |
@@ -113,7 +111,7 @@ CRUD operations for managing nodes in the system.
 }
 ```
 
-#### Response Format:
+**Response Format:**
 
 ```json
 {
@@ -138,13 +136,13 @@ CRUD operations for managing nodes in the system.
 
 **Description:** Retrieves details of a specific node by its ID.
 
-#### Request Parameters
+**Request Parameters:**
 
 | Parameter | Type   | Location | Required | Description           |
 | --------- | ------ | -------- | -------- | --------------------- |
 | node_id   | string | params   | Yes      | UUID of the node      |
 
-#### Response Format:
+**Response Format:**
 
 ```json
 {
@@ -169,7 +167,7 @@ CRUD operations for managing nodes in the system.
 
 **Description:** Updates an existing node's information.
 
-#### Request Parameters
+**Request Parameters:**
 
 | Parameter      | Type   | Location | Required | Description                           |
 | -------------- | ------ | -------- | -------- | ------------------------------------- |
@@ -191,7 +189,7 @@ CRUD operations for managing nodes in the system.
 }
 ```
 
-#### Response Format:
+**Response Format:**
 
 ```json
 {
@@ -216,13 +214,13 @@ CRUD operations for managing nodes in the system.
 
 **Description:** Soft deletes a node by setting its status to inactive.
 
-#### Request Parameters
+**Request Parameters:**
 
 | Parameter | Type   | Location | Required | Description           |
 | --------- | ------ | -------- | -------- | --------------------- |
 | node_id   | string | params   | Yes      | UUID of the node      |
 
-#### Response Format:
+**Response Format:**
 
 ```json
 {
@@ -242,16 +240,16 @@ CRUD operations for managing nodes in the system.
 
 **Description:** Retrieves a list of all nodes with optional filtering.
 
-#### Request Parameters
+**Request Parameters:**
 
 | Parameter   | Type   | Location | Required | Description                    |
 | ----------- | ------ | -------- | -------- | ------------------------------ |
 | node_type   | string | query    | No       | Filter by node type            |
-| status      | string | query    | No       | Filter by status               |
+| status      | string | query    | No       | Filter by status (default: Active)               |
 | page_size   | number | query    | No       | Items per page (default: 50)  |
 | page        | number | query    | No       | Page number (default: 1)      |
 
-#### Response Format:
+Response Format:**
 
 ```json
 {
@@ -294,7 +292,7 @@ CRUD operations for managing item types in the system.
 
 **Description:** Creates a new item type in the system.
 
-#### Request Parameters
+**Request Parameters:**
 
 | Parameter         | Type   | Location | Required | Description                      |
 | ----------------- | ------ | -------- | -------- | -------------------------------- |
@@ -316,7 +314,7 @@ CRUD operations for managing item types in the system.
 }
 ```
 
-#### Response Format:
+**Response Format:**
 
 ```json
 {
@@ -340,13 +338,13 @@ CRUD operations for managing item types in the system.
 
 **Description:** Retrieves details of a specific item type by its ID.
 
-#### Request Parameters
+**Request Parameters:**
 
 | Parameter | Type   | Location | Required | Description              |
 | --------- | ------ | -------- | -------- | ------------------------ |
 | item_id   | string | params   | Yes      | UUID of the item type    |
 
-#### Response Format:
+**Response Format:**
 
 ```json
 {
@@ -370,7 +368,7 @@ CRUD operations for managing item types in the system.
 
 **Description:** Updates an existing item type's information.
 
-#### Request Parameters
+**Request Parameters:**
 
 | Parameter         | Type   | Location | Required | Description                      |
 | ----------------- | ------ | -------- | -------- | -------------------------------- |
@@ -381,7 +379,7 @@ CRUD operations for managing item types in the system.
 | item_image        | string | body     | No       | URL/path to item image           |
 | status            | string | body     | No       | Status (Active, Inactive)        |
 
-#### Response Format:
+**Response Format:**
 
 ```json
 {
@@ -405,13 +403,13 @@ CRUD operations for managing item types in the system.
 
 **Description:** Soft deletes an item type by setting its status to inactive.
 
-#### Request Parameters
+**Request Parameters:**
 
 | Parameter | Type   | Location | Required | Description              |
 | --------- | ------ | -------- | -------- | ------------------------ |
 | item_id   | string | params   | Yes      | UUID of the item type    |
 
-#### Response Format:
+**Response Format:**
 
 ```json
 {
@@ -431,16 +429,16 @@ CRUD operations for managing item types in the system.
 
 **Description:** Retrieves a list of all item types with optional filtering.
 
-#### Request Parameters
+**Request Parameters:**
 
 | Parameter  | Type   | Location | Required | Description                    |
 | ---------- | ------ | -------- | -------- | ------------------------------ |
 | item_type  | string | query    | No       | Filter by category             |
-| status     | string | query    | No       | Filter by status               |
+| status     | string | query    | No       | Filter by status (default: Active)               |
 | page_size  | number | query    | No       | Items per page (default: 50)  |
 | page       | number | query    | No       | Page number (default: 1)      |
 
-#### Response Format:
+**Response Format:**
 
 ```json
 {
@@ -482,7 +480,7 @@ CRUD operations for managing item instances in the system.
 
 **Description:** Creates a new item instance in the system.
 
-#### Request Parameters
+**Request Parameters:**
 
 | Parameter      | Type   | Location | Required | Description                           |
 | -------------- | ------ | -------- | -------- | ------------------------------------- |
@@ -504,7 +502,7 @@ CRUD operations for managing item instances in the system.
 }
 ```
 
-#### Response Format:
+**Response Format:**
 
 ```json
 {
@@ -528,13 +526,13 @@ CRUD operations for managing item instances in the system.
 
 **Description:** Retrieves details of a specific item instance by its ID.
 
-#### Request Parameters
+**Request Parameters:**
 
 | Parameter          | Type   | Location | Required | Description                    |
 | ------------------ | ------ | -------- | -------- | ------------------------------ |
 | item_instance_id   | string | params   | Yes      | UUID of the item instance      |
 
-#### Response Format:
+**Response Format:**
 
 ```json
 {
@@ -569,7 +567,7 @@ CRUD operations for managing item instances in the system.
 
 **Description:** Retrieves all active item instances across the system with their details.
 
-#### Request Parameters
+**Request Parameters:**
 
 | Parameter    | Type   | Location | Required | Description                           |
 | ------------ | ------ | -------- | -------- | ------------------------------------- |
@@ -579,7 +577,7 @@ CRUD operations for managing item instances in the system.
 | page_size    | number | query    | No       | Items per page (default: 50)         |
 | page         | number | query    | No       | Page number (default: 1)             |
 
-#### Response Format:
+**Response Format:**
 
 ```json
 {
@@ -656,7 +654,7 @@ CRUD operations for managing item instances in the system.
 
 **Description:** Updates an existing item instance's information.
 
-#### Request Parameters
+**Request Parameters:**
 
 | Parameter          | Type   | Location | Required | Description                           |
 | ------------------ | ------ | -------- | -------- | ------------------------------------- |
@@ -666,7 +664,7 @@ CRUD operations for managing item instances in the system.
 | expire_date        | string | body     | No       | Expiration date (ISO format)          |
 | status             | string | body     | No       | Status (Active, Inactive)             |
 
-#### Response Format:
+**Response Format:**
 
 ```json
 {
@@ -690,13 +688,13 @@ CRUD operations for managing item instances in the system.
 
 **Description:** Soft deletes an item instance by setting its status to inactive.
 
-#### Request Parameters
+**Request Parameters:**
 
 | Parameter          | Type   | Location | Required | Description                    |
 | ------------------ | ------ | -------- | -------- | ------------------------------ |
 | item_instance_id   | string | params   | Yes      | UUID of the item instance      |
 
-#### Response Format:
+**Response Format:**
 
 ```json
 {
@@ -716,18 +714,18 @@ CRUD operations for managing item instances in the system.
 
 **Description:** Retrieves item instances with optional filtering by node.
 
-#### Request Parameters
+**Request Parameters:**
 
 | Parameter    | Type   | Location | Required | Description                    |
 | ------------ | ------ | -------- | -------- | ------------------------------ |
 | node_id      | string | query    | No       | Filter by node ID              |
 | item_type_id | string | query    | No       | Filter by item type            |
-| status       | string | query    | No       | Filter by status               |
+| status       | string | query    | No       | Filter by status (default: Active)               |
 | expired      | boolean| query    | No       | Show expired items only        |
 | page_size    | number | query    | No       | Items per page (default: 50)  |
 | page         | number | query    | No       | Page number (default: 1)      |
 
-#### Response Format:
+**Response Format:**
 
 ```json
 {
@@ -777,7 +775,7 @@ CRUD operations for managing item transits in the system.
 
 **Description:** Creates a new item transit record when item starts moving between nodes.
 
-#### Request Parameters
+**Request Parameters:**
 
 | Parameter         | Type   | Location | Required | Description                           |
 | ----------------- | ------ | -------- | -------- | ------------------------------------- |
@@ -805,7 +803,7 @@ CRUD operations for managing item transits in the system.
 }
 ```
 
-#### Response Format:
+**Response Format:**
 
 ```json
 {
@@ -833,13 +831,13 @@ CRUD operations for managing item transits in the system.
 
 **Description:** Retrieves details of a specific item transit by its ID.
 
-#### Request Parameters
+**Request Parameters:**
 
 | Parameter         | Type   | Location | Required | Description                    |
 | ----------------- | ------ | -------- | -------- | ------------------------------ |
 | item_transit_id   | string | params   | Yes      | UUID of the transit record     |
 
-#### Response Format:
+**Response Format:**
 
 ```json
 {
@@ -882,7 +880,7 @@ CRUD operations for managing item transits in the system.
 
 **Description:** Updates an existing item transit's information.
 
-#### Request Parameters
+**Request Parameters:**
 
 | Parameter         | Type   | Location | Required | Description                           |
 | ----------------- | ------ | -------- | -------- | ------------------------------------- |
@@ -893,7 +891,7 @@ CRUD operations for managing item transits in the system.
 | courier_phone     | string | body     | No       | Phone number of courier               |
 | status            | string | body     | No       | Status (Active, Inactive, Completed)  |
 
-#### Response Format:
+**Response Format:**
 
 ```json
 {
@@ -916,14 +914,14 @@ CRUD operations for managing item transits in the system.
 
 **Description:** Marks an item transit as completed and updates arrival time.
 
-#### Request Parameters
+**Request Parameters:**
 
 | Parameter        | Type   | Location | Required | Description                    |
 | ---------------- | ------ | -------- | -------- | ------------------------------ |
 | item_transit_id  | string | params   | Yes      | UUID of the transit record     |
 | time_arrival     | string | body     | Yes      | Arrival time (ISO format)      |
 
-#### Response Format:
+**Response Format:**
 
 ```json
 {
@@ -953,18 +951,18 @@ CRUD operations for managing item transits in the system.
 
 **Description:** Retrieves active transit records with optional filtering.
 
-#### Request Parameters
+**Request Parameters:**
 
 | Parameter        | Type   | Location | Required | Description                    |
 | ---------------- | ------ | -------- | -------- | ------------------------------ |
 | source_node_id   | string | query    | No       | Filter by source node          |
 | dest_node_id     | string | query    | No       | Filter by destination node     |
-| status           | string | query    | No       | Filter by status               |
+| status           | string | query    | No       | Filter by status (default: Active)               |
 | courier_name     | string | query    | No       | Filter by courier name         |
 | page_size        | number | query    | No       | Items per page (default: 50)  |
 | page             | number | query    | No       | Page number (default: 1)      |
 
-#### Response Format:
+**Response Format:**
 
 ```json
 {

--- a/docs/API/postman/DesproCrud.postman_collection.json
+++ b/docs/API/postman/DesproCrud.postman_collection.json
@@ -1,0 +1,157 @@
+{
+	"info": {
+		"_postman_id": "58b77c92-dc4f-488f-9114-db4ab15a3419",
+		"name": "DesproCrud",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "31046090"
+	},
+	"item": [
+		{
+			"name": "Node",
+			"item": [
+				{
+					"name": "List Node",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{url}}/api/nodes?status=inactive",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"nodes"
+							],
+							"query": [
+								{
+									"key": "node_type",
+									"value": null,
+									"description": "Filter by node type",
+									"disabled": true
+								},
+								{
+									"key": "status",
+									"value": "inactive",
+									"description": "Filter by status (default: active)"
+								},
+								{
+									"key": "page_size",
+									"value": null,
+									"description": "Items per page (default: 50)",
+									"disabled": true
+								},
+								{
+									"key": "page",
+									"value": null,
+									"description": "Page number (default: 1)  ",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create Node",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"node_name\": \"Node B\",\r\n  \"node_type\": \"Source\",\r\n  \"node_address\": \"Jalan Merdeka No. 123, Jakarta\",\r\n  \"node_latitude\": -20.000000,\r\n  \"node_longitude\": 100.000000,\r\n  \"node_status\": \"Active\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{url}}/api/node",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"node"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Read Node",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{url}}/api/node/:node_id",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"node",
+								":node_id"
+							],
+							"variable": [
+								{
+									"key": "node_id",
+									"value": "eee2b3a2-67b2-4611-a07c-17a5f0594fe5"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "List Transit",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{url}}/api/item-transits",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"api",
+						"item-transits"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "url",
+			"value": "http://localhost:3000",
+			"type": "string"
+		}
+	]
+}

--- a/lib/api-helpers.ts
+++ b/lib/api-helpers.ts
@@ -1,0 +1,166 @@
+import { NextResponse } from 'next/server';
+import { ApiResponse, PaginationMeta, PaginationParams } from './api-types';
+import { createClient } from '@/utils/supabase/server';
+
+// API Response Helpers
+export function createSuccessResponse<T>(message: string, data?: T): NextResponse {
+  const response: ApiResponse<T> = {
+    success: true,
+    message,
+    data
+  };
+  return NextResponse.json(response);
+}
+
+export function createErrorResponse(message: string, statusCode: number = 400): NextResponse {
+  const response: ApiResponse = {
+    success: false,
+    message,
+    error: message
+  };
+  return NextResponse.json(response, { status: statusCode });
+}
+
+// Pagination Helpers
+export function getPaginationParams(searchParams: URLSearchParams): PaginationParams {
+  const page = parseInt(searchParams.get('page') || '1');
+  const page_size = parseInt(searchParams.get('page_size') || '50');
+  
+  return {
+    page: Math.max(1, page),
+    page_size: Math.min(Math.max(1, page_size), 100) // Cap at 100 items per page
+  };
+}
+
+export function createPaginationMeta(
+  totalItems: number,
+  currentPage: number,
+  itemsPerPage: number
+): PaginationMeta {
+  const totalPages = Math.ceil(totalItems / itemsPerPage);
+  
+  return {
+    total_items: totalItems,
+    current_page: currentPage,
+    items_per_page: itemsPerPage,
+    total_pages: totalPages,
+    has_next: currentPage < totalPages,
+    has_previous: currentPage > 1
+  };
+}
+
+// Database Helpers
+export async function getSupabaseClient() {
+  try {
+    const supabase = await createClient();
+    return supabase;
+  } catch (error) {
+    console.error('Failed to create Supabase client:', error);
+    throw new Error('Database connection failed');
+  }
+}
+
+// Request Validation Helpers
+export function validateRequired(obj: any, requiredFields: string[]): string[] {
+  const missing: string[] = [];
+  
+  for (const field of requiredFields) {
+    if (!obj[field] || (typeof obj[field] === 'string' && obj[field].trim() === '')) {
+      missing.push(field);
+    }
+  }
+  
+  return missing;
+}
+
+export function validateUUID(id: string): boolean {
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  return uuidRegex.test(id);
+}
+
+// Data Transformation Helpers
+export function transformDbToApi<T extends Record<string, any>>(
+  dbRecord: T,
+  mapping?: Record<string, string>
+): any {
+  if (!mapping) return dbRecord;
+  
+  const transformed: any = {};
+  for (const [apiKey, dbKey] of Object.entries(mapping)) {
+    if (dbRecord.hasOwnProperty(dbKey)) {
+      transformed[apiKey] = dbRecord[dbKey];
+    }
+  }
+  
+  // Include any unmapped fields
+  for (const key of Object.keys(dbRecord)) {
+    if (!Object.values(mapping).includes(key) && !transformed.hasOwnProperty(key)) {
+      transformed[key] = dbRecord[key];
+    }
+  }
+  
+  return transformed;
+}
+
+// Common database field mappings
+export const NODE_FIELD_MAPPING = {
+  'node_id': 'node_id', // Database uses node_id, not id
+  'node_name': 'node_name',
+  'node_type': 'node_type',
+  'node_address': 'node_address',
+  'node_latitude': 'node_latitude',
+  'node_longitude': 'node_longitude',
+  'node_status': 'node_status',
+  'created_at': 'created_at'
+};
+
+export const ITEM_TYPE_FIELD_MAPPING = {
+  'item_id': 'item_id', // Likely uses item_id, not id
+  'item_name': 'item_name',
+  'item_type': 'item_type',
+  'item_description': 'item_description',
+  'item_image': 'item_image',
+  'status': 'status',
+  'created_at': 'created_at'
+};
+
+export const ITEM_INSTANCE_FIELD_MAPPING = {
+  'item_instance_id': 'item_instance_id', // Likely uses item_instance_id, not id
+  'item_type_id': 'item_type_id',
+  'node_id': 'node_id',
+  'item_count': 'item_count',
+  'expire_date': 'expire_date',
+  'status': 'status',
+  'created_at': 'created_at'
+};
+
+export const ITEM_TRANSIT_FIELD_MAPPING = {
+  'item_transit_id': 'item_transit_id', // Likely uses item_transit_id, not id
+  'item_instance_id': 'item_instance_id',
+  'source_node_id': 'source_node_id',
+  'dest_node_id': 'dest_node_id',
+  'time_departure': 'time_departure',
+  'time_arrival': 'time_arrival',
+  'courier_name': 'courier_name',
+  'courier_phone': 'courier_phone',
+  'qr_url': 'qr_url'
+  // 'status': 'status', // Temporarily commented out - column may not exist
+  // 'created_at': 'created_at' // Temporarily commented out - column may not exist
+};
+
+// Error handling wrapper
+export async function handleApiError<T>(
+  operation: () => Promise<T>
+): Promise<T | NextResponse> {
+  try {
+    return await operation();
+  } catch (error) {
+    console.error('API Error:', error);
+    
+    if (error instanceof Error) {
+      return createErrorResponse(error.message, 500);
+    }
+    
+    return createErrorResponse('An unexpected error occurred', 500);
+  }
+}

--- a/lib/api-types.ts
+++ b/lib/api-types.ts
@@ -1,0 +1,241 @@
+// API Types and Interfaces
+export interface ApiResponse<T = any> {
+  success: boolean;
+  message: string;
+  data?: T;
+  error?: string;
+}
+
+export interface PaginationParams {
+  page?: number;
+  page_size?: number;
+}
+
+export interface PaginationMeta {
+  total_items: number;
+  current_page: number;
+  items_per_page: number;
+  total_pages: number;
+  has_next: boolean;
+  has_previous: boolean;
+}
+
+export interface PaginatedResponse<T> {
+  items: T[];
+  pagination: PaginationMeta;
+}
+
+// Node Types
+export interface NodeData {
+  node_id: string;
+  node_name: string;
+  node_type: 'Source' | 'Assembly' | 'Distribution';
+  node_address?: string;
+  node_latitude?: number;
+  node_longitude?: number;
+  node_status: 'Active' | 'Inactive'; // 'Active' = active, 'Inactive' = disabled
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface CreateNodeRequest {
+  node_name: string;
+  node_type: 'Source' | 'Assembly' | 'Distribution';
+  node_address?: string;
+  node_latitude?: number;
+  node_longitude?: number;
+  node_status?: boolean;
+}
+
+export interface UpdateNodeRequest {
+  node_name?: string;
+  node_type?: 'Source' | 'Assembly' | 'Distribution';
+  node_address?: string;
+  node_latitude?: number;
+  node_longitude?: number;
+  node_status?: boolean;
+}
+
+// Item Type Types
+export interface ItemTypeData {
+  item_id: string;
+  item_name: string;
+  item_type: string;
+  item_description?: string;
+  item_image?: string;
+  status: 'Active' | 'Inactive'; // 'Active' = active, 'Inactive' = disabled
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface CreateItemTypeRequest {
+  item_name: string;
+  item_type: string;
+  item_description?: string;
+  item_image?: string;
+  status?: boolean;
+}
+
+export interface UpdateItemTypeRequest {
+  item_name?: string;
+  item_type?: string;
+  item_description?: string;
+  item_image?: string;
+  status?: boolean;
+}
+
+// Item Instance Types
+export interface ItemInstanceData {
+  item_instance_id: string;
+  item_type_id: string;
+  node_id?: string;
+  item_count: number;
+  expire_date?: string;
+  status: 'Active' | 'Inactive'; // 'Active' = active, 'Inactive' = disabled
+  created_at?: string;
+  updated_at?: string;
+  item_type?: {
+    item_id: string;
+    item_name: string;
+    item_type: string;
+    item_description?: string;
+    item_image?: string;
+  };
+  current_node?: {
+    node_id: string;
+    node_name: string;
+    node_type: string;
+    node_address?: string;
+  };
+  current_transit?: {
+    transit_id: string;
+    source_node: {
+      node_id: string;
+      node_name: string;
+    };
+    dest_node_id: string;
+    time_departure: string;
+  };
+}
+
+export interface CreateItemInstanceRequest {
+  item_type_id: string;
+  node_id?: string;
+  item_count: number;
+  expire_date?: string;
+  status?: boolean;
+}
+
+export interface UpdateItemInstanceRequest {
+  node_id?: string;
+  item_count?: number;
+  expire_date?: string;
+  status?: boolean;
+}
+
+// Item Transit Types
+export interface ItemTransitData {
+  item_transit_id: string;
+  item_instance_id: string;
+  source_node_id: string;
+  dest_node_id?: string;
+  time_departure: string;
+  time_arrival?: string;
+  courier_name?: string;
+  courier_phone?: string;
+  qr_url?: string;
+  status: 'Active' | 'Completed' | 'Inactive';
+  created_at?: string;
+  updated_at?: string;
+  item_instance?: {
+    item_instance_id: string;
+    item_count: number;
+    item_type: {
+      item_name: string;
+      item_type: string;
+    };
+  };
+  source_node?: {
+    node_id: string;
+    node_name: string;
+    node_type: string;
+  };
+  dest_node?: {
+    node_id: string;
+    node_name: string;
+    node_type: string;
+  };
+}
+
+export interface CreateItemTransitRequest {
+  item_instance_id: string;
+  source_node_id: string;
+  dest_node_id?: string;
+  time_departure: string;
+  courier_name?: string;
+  courier_phone?: string;
+  qr_url?: string;
+  status?: 'Active' | 'Completed' | 'Inactive';
+}
+
+export interface UpdateItemTransitRequest {
+  dest_node_id?: string;
+  time_arrival?: string;
+  courier_name?: string;
+  courier_phone?: string;
+  status?: 'Active' | 'Completed' | 'Inactive';
+}
+
+export interface CompleteTransitRequest {
+  time_arrival: string;
+}
+
+// Database column mappings (if different from API)
+export interface DbNode {
+  id: string;
+  node_name: string;
+  node_type: string;
+  node_address?: string;
+  node_latitude?: number;
+  node_longitude?: number;
+  node_status: 'Active' | 'Inactive';
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DbItemType {
+  id: string;
+  item_name: string;
+  item_type: string;
+  item_description?: string;
+  item_image?: string;
+  status: 'Active' | 'Inactive';
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DbItemInstance {
+  id: string;
+  item_type_id: string;
+  node_id?: string;
+  item_count: number;
+  expire_date?: string;
+  status: 'Active' | 'Inactive';
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DbItemTransit {
+  id: string;
+  item_instance_id: string;
+  source_node_id: string;
+  dest_node_id?: string;
+  time_departure: string;
+  time_arrival?: string;
+  courier_name?: string;
+  courier_phone?: string;
+  qr_url?: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "web-despro",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.1.1",
         "@radix-ui/react-dropdown-menu": "^2.1.1",


### PR DESCRIPTION
- Implement POST /api/node to create a new node with validation.
- Implement GET /api/nodes to list all nodes with filtering and pagination.
- Implement POST /api/transit to create item transit with validation and error handling.
- Update API documentation to reflect new endpoints and request/response formats.
- Add Postman collection for testing the new API endpoints.
- Introduce helper functions for API response creation, pagination, and validation.
- Define TypeScript interfaces for API request and response types.